### PR TITLE
Release-1.0.0

### DIFF
--- a/.github/workflows/courier.yml
+++ b/.github/workflows/courier.yml
@@ -52,7 +52,10 @@ jobs:
             Automated PR Creation in Public Remote Repository
             
             v${{ steps.version.outputs.major}}.${{ steps.version.outputs.minor}}.${{ steps.version.outputs.patch}}
-
+            
+            # Next Things to Test
+            - are Major Versions tracked without dropped a Tagged Version?
+            - how best should this Occur?
 
           pr_label: 'release'
           


### PR DESCRIPTION
:crown: *An automated PR*

# Things Accomplished:
Automated PR Creation in Public Remote Repository

v1.0.0

# Next Things to Test
- are Major Versions tracked without dropped a Tagged Version?
- how best should this Occur?