### PR TITLE
Release-1.0.0

### DIFF
--- a/.github/workflows/courier.yml
+++ b/.github/workflows/courier.yml
@@ -42,6 +42,7 @@ jobs:
         uses: repo-sync/pull-request@v2 
         with:
           github_token: ${{ secrets.ACCESS_TOKEN }}
+          source_branch: Release-${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{steps.version.outputs.patch}}
           destination_branch: "main"
           destination_repository: "todd-miller/code-courier-landing"
           pr_title: "Release-${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{steps.version.outputs.patch}}"

--- a/.github/workflows/courier.yml
+++ b/.github/workflows/courier.yml
@@ -52,7 +52,10 @@ jobs:
             Automated PR Creation in Public Remote Repository
             
             v${{ steps.version.outputs.major}}.${{ steps.version.outputs.minor}}.${{ steps.version.outputs.patch}}
-
+            
+            # Next Things to Test
+            - are Major Versions tracked without dropped a Tagged Version?
+            - how best should this Occur?
 
           pr_label: 'release'
           

--- a/.github/workflows/courier.yml
+++ b/.github/workflows/courier.yml
@@ -57,6 +57,7 @@ jobs:
             # Next Things to Test
             - are Major Versions tracked without dropped a Tagged Version?
             - how best should this Occur?
+            - I think I need to tag releases so i can increment accordingly
 
           pr_label: 'release'
           


### PR DESCRIPTION
:crown: *An automated PR*

# Things Accomplished:
Automated PR Creation in Public Remote Repository

v1.0.0

# Next Things to Test
- are Major Versions tracked without dropped a Tagged Version?
- how best should this Occur?